### PR TITLE
Always delete data at lastIndex.

### DIFF
--- a/contracts/ERC721R.sol
+++ b/contracts/ERC721R.sol
@@ -315,19 +315,21 @@ contract ERC721r is Context, ERC165, IERC721, IERC721Metadata {
         }
 
         uint256 lastIndex = updatedNumAvailableTokens - 1;
+        uint256 lastValInArray = _availableTokens[lastIndex];
         if (indexToUse != lastIndex) {
             // Replace the value at indexToUse, now that it's been used.
             // Replace it with the data from the last index in the array, since we are going to decrease the array size afterwards.
-            uint256 lastValInArray = _availableTokens[lastIndex];
             if (lastValInArray == 0) {
                 // This means the index itself is still an available token
                 _availableTokens[indexToUse] = lastIndex;
             } else {
                 // This means the index itself is not an available token, but the val at that index is.
                 _availableTokens[indexToUse] = lastValInArray;
-                // Gas refund courtsey of @dievardump
-                delete _availableTokens[lastIndex];
             }
+        }
+        if (lastValInArray != 0) {
+            // Gas refund courtsey of @dievardump
+            delete _availableTokens[lastIndex];
         }
         
         return result;


### PR DESCRIPTION
The current code will not `delete _availableTokens[lastIndex]`, when `indexToUse` happens to be the same as `lastIndex`.

We fixed this issue with this commit.